### PR TITLE
Revert "update SpeziStudy (#29)"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         .executable(name: "MHCStudyDefinitionExporterCLI", targets: ["MHCStudyDefinitionExporterCLI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.7.7"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziStudy.git", .upToNextMinor(from: "0.2.2")),
+        .package(url: "https://github.com/StanfordSpezi/SpeziStudy.git", .upToNextMinor(from: "0.1.19")),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.4.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.2"),
         // not used directly but we need to fix it below 0.9.0 for the time being
         .package(url: "https://github.com/apple/FHIRModels.git", .upToNextMinor(from: "0.8.0"))
@@ -54,7 +54,8 @@ let package = Package(
                 .copy("Resources/article"),
                 .copy("Resources/questionnaire"),
                 .copy("Resources/hhdExplainer")
-            ]
+            ],
+            swiftSettings: [.defaultIsolation(MainActor.self)]
         ),
         .executableTarget(
             name: "MHCStudyDefinitionExporterCLI",
@@ -63,7 +64,8 @@ let package = Package(
                 "MHCStudyDefinitionExporter",
                 .product(name: "SpeziStudyDefinition", package: "SpeziStudy"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
-            ]
+            ],
+            swiftSettings: [.defaultIsolation(MainActor.self)]
         ),
         .testTarget(
             name: "MHCStudyDefinitionExporterTests",

--- a/Sources/MHCStudyDefinitionExporter/Study.swift
+++ b/Sources/MHCStudyDefinitionExporter/Study.swift
@@ -12,7 +12,6 @@ import Foundation
 import MHCStudyDefinition
 import SpeziHealthKit
 import enum SpeziHealthKitBulkExport.ExportSessionStartDate
-import SpeziLocalization
 import SpeziScheduler
 import SpeziStudyDefinition
 
@@ -39,18 +38,17 @@ extension StudyBundle.FileReference {
 
 
 let mhcStudyDefinition = StudyDefinition(
-    studyRevision: 39,
+    studyRevision: 38,
     metadata: .init(
         id: .mhcStudy,
-        title: [.enUS: "My Heart Counts"],
-        shortTitle: [.enUS: "MHC"],
+        title: "My Heart Counts",
+        shortTitle: "MHC",
         icon: .systemSymbol("cube.transparent"),
-        explanationText: [:],
-        shortExplanationText: [
-            .enUS: "Improve your cardiovascular health"
-        ],
+        explanationText: "",
+        shortExplanationText: "Improve your cardiovascular health",
         studyDependency: nil,
         participationCriterion: .ageAtLeast(18) && (.isFromRegion(.unitedStates) || .isFromRegion(.unitedKingdom)),
+        enrollmentConditions: .none,
         consentFileRef: .init(category: .consent, filename: "Consent", fileExtension: "md")
     ),
     components: [


### PR DESCRIPTION
This reverts commit 467af8137a17ffcda0adc83f251219dfb23f8594.

# Revert "update SpeziStudy (#29)"

## :recycle: Current situation & Problem
i messed up the releases


## :gear: Release Notes
- Revert "update SpeziStudy (#29)" (467af8137a17ffcda0adc83f251219dfb23f8594)


## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
