### PR TITLE
[breaking change] update to new SpeziStudy release

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,11 +27,9 @@ let package = Package(
         .executable(name: "MHCStudyDefinitionExporterCLI", targets: ["MHCStudyDefinitionExporterCLI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziStudy.git", .upToNextMinor(from: "0.1.19")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.4.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.2"),
-        // not used directly but we need to fix it below 0.9.0 for the time being
-        .package(url: "https://github.com/apple/FHIRModels.git", .upToNextMinor(from: "0.8.0"))
+        .package(url: "https://github.com/StanfordSpezi/SpeziStudy.git", revision: "e11803b1897930da7c374085606814e82622bdf3"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.7.7"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.2")
     ],
     targets: [
         .target(
@@ -54,8 +52,7 @@ let package = Package(
                 .copy("Resources/article"),
                 .copy("Resources/questionnaire"),
                 .copy("Resources/hhdExplainer")
-            ],
-            swiftSettings: [.defaultIsolation(MainActor.self)]
+            ]
         ),
         .executableTarget(
             name: "MHCStudyDefinitionExporterCLI",
@@ -64,8 +61,7 @@ let package = Package(
                 "MHCStudyDefinitionExporter",
                 .product(name: "SpeziStudyDefinition", package: "SpeziStudy"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
-            ],
-            swiftSettings: [.defaultIsolation(MainActor.self)]
+            ]
         ),
         .testTarget(
             name: "MHCStudyDefinitionExporterTests",

--- a/Sources/MHCStudyDefinitionExporter/Study.swift
+++ b/Sources/MHCStudyDefinitionExporter/Study.swift
@@ -12,6 +12,7 @@ import Foundation
 import MHCStudyDefinition
 import SpeziHealthKit
 import enum SpeziHealthKitBulkExport.ExportSessionStartDate
+import SpeziLocalization
 import SpeziScheduler
 import SpeziStudyDefinition
 
@@ -38,17 +39,16 @@ extension StudyBundle.FileReference {
 
 
 let mhcStudyDefinition = StudyDefinition(
-    studyRevision: 40,
+    studyRevision: 41,
     metadata: .init(
         id: .mhcStudy,
-        title: "My Heart Counts",
-        shortTitle: "MHC",
+        title: [.enUS: "My Heart Counts"],
+        shortTitle: [.enUS: "MHC"],
         icon: .systemSymbol("cube.transparent"),
-        explanationText: "",
-        shortExplanationText: "Improve your cardiovascular health",
+        explanationText: [:],
+        shortExplanationText: [.enUS: "Improve your cardiovascular health"],
         studyDependency: nil,
         participationCriterion: .ageAtLeast(18) && (.isFromRegion(.unitedStates) || .isFromRegion(.unitedKingdom)),
-        enrollmentConditions: .none,
         consentFileRef: .init(category: .consent, filename: "Consent", fileExtension: "md")
     ),
     components: [


### PR DESCRIPTION
# [breaking change] update to new SpeziStudy release


**Note** this is a breaking change so we'll need to coordinate the release with a corresponding MHC app release

## :gear: Release Notes
- updates SpeziStudy to 0.2.x release


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
