### PR TITLE
[breaking change] update deps

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .executable(name: "MHCStudyDefinitionExporterCLI", targets: ["MHCStudyDefinitionExporterCLI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", revision: "fe1fad25ddec0dfb7d7e10ced4658e945dec6638"),
+        .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", .upToNextMinor(from: "0.1.0")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.2")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .executable(name: "MHCStudyDefinitionExporterCLI", targets: ["MHCStudyDefinitionExporterCLI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", branch: "monorepo-import"),
+        .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", revision: "d0f1e1cee93392ee7a0d64849a8dbf107d98a39e"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.2")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .executable(name: "MHCStudyDefinitionExporterCLI", targets: ["MHCStudyDefinitionExporterCLI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", .upToNextMinor(from: "0.1.0")),
+        .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", revision: "fe1fad25ddec0dfb7d7e10ced4658e945dec6638"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.2")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,6 @@ let package = Package(
     platforms: [
         .iOS(.v18),
         .watchOS(.v11),
-        .visionOS(.v2),
         .macOS(.v15),
         .macCatalyst(.v18)
     ],
@@ -27,17 +26,14 @@ let package = Package(
         .executable(name: "MHCStudyDefinitionExporterCLI", targets: ["MHCStudyDefinitionExporterCLI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziStudy.git", .upToNextMinor(from: "0.1.19")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.4.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.2"),
-        // not used directly but we need to fix it below 0.9.0 for the time being
-        .package(url: "https://github.com/apple/FHIRModels.git", .upToNextMinor(from: "0.8.0"))
+        .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", branch: "monorepo-import"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.2")
     ],
     targets: [
         .target(
             name: "MHCStudyDefinition",
             dependencies: [
-                .product(name: "SpeziStudyDefinition", package: "SpeziStudy")
+                .product(name: "SpeziStudyDefinition", package: "Spezi")
             ],
             resources: [.process("Resources")]
         ),
@@ -45,34 +41,32 @@ let package = Package(
             name: "MHCStudyDefinitionExporter",
             dependencies: [
                 "MHCStudyDefinition",
-                .product(name: "SpeziStudyDefinition", package: "SpeziStudy"),
-                .product(name: "SpeziStudy", package: "SpeziStudy"),
-                .product(name: "SpeziLocalization", package: "SpeziFoundation")
+                .product(name: "SpeziStudyDefinition", package: "Spezi"),
+                .product(name: "SpeziStudy", package: "Spezi"),
+                .product(name: "SpeziLocalization", package: "Spezi")
             ],
             resources: [
                 .copy("Resources/consent"),
                 .copy("Resources/article"),
                 .copy("Resources/questionnaire"),
                 .copy("Resources/hhdExplainer")
-            ],
-            swiftSettings: [.defaultIsolation(MainActor.self)]
+            ]
         ),
         .executableTarget(
             name: "MHCStudyDefinitionExporterCLI",
             dependencies: [
                 "MHCStudyDefinition",
                 "MHCStudyDefinitionExporter",
-                .product(name: "SpeziStudyDefinition", package: "SpeziStudy"),
+                .product(name: "SpeziStudyDefinition", package: "Spezi"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
-            ],
-            swiftSettings: [.defaultIsolation(MainActor.self)]
+            ]
         ),
         .testTarget(
             name: "MHCStudyDefinitionExporterTests",
             dependencies: [
                 "MHCStudyDefinition",
                 "MHCStudyDefinitionExporter",
-                .product(name: "SpeziStudyDefinition", package: "SpeziStudy")
+                .product(name: "SpeziStudyDefinition", package: "Spezi")
             ]
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .executable(name: "MHCStudyDefinitionExporterCLI", targets: ["MHCStudyDefinitionExporterCLI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", revision: "d0f1e1cee93392ee7a0d64849a8dbf107d98a39e"),
+        .package(url: "https://github.com/SchmiedmayerLab/Spezi.git", .upToNextMinor(from: "0.1.0")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.2")
     ],
     targets: [

--- a/Sources/MHCStudyDefinitionExporter/Study.swift
+++ b/Sources/MHCStudyDefinitionExporter/Study.swift
@@ -12,6 +12,7 @@ import Foundation
 import MHCStudyDefinition
 import SpeziHealthKit
 import enum SpeziHealthKitBulkExport.ExportSessionStartDate
+import SpeziLocalization
 import SpeziScheduler
 import SpeziStudyDefinition
 
@@ -38,17 +39,16 @@ extension StudyBundle.FileReference {
 
 
 let mhcStudyDefinition = StudyDefinition(
-    studyRevision: 40,
+    studyRevision: 41,
     metadata: .init(
         id: .mhcStudy,
-        title: "My Heart Counts",
-        shortTitle: "MHC",
+        title: [.enUS: "My Heart Counts"],
+        shortTitle: [.enUS: "MHC"],
         icon: .systemSymbol("cube.transparent"),
-        explanationText: "",
-        shortExplanationText: "Improve your cardiovascular health",
+        explanationText: [:],
+        shortExplanationText: [.enUS: "Improve your cardiovascular health"],
         studyDependency: nil,
         participationCriterion: .ageAtLeast(18) && (.isFromRegion(.unitedStates) || .isFromRegion(.unitedKingdom)),
-        enrollmentConditions: .none,
         consentFileRef: .init(category: .consent, filename: "Consent", fileExtension: "md")
     ),
     components: [

--- a/Sources/MHCStudyDefinitionExporter/Study.swift
+++ b/Sources/MHCStudyDefinitionExporter/Study.swift
@@ -46,7 +46,10 @@ let mhcStudyDefinition = StudyDefinition(
         shortTitle: [.enUS: "MHC"],
         icon: .systemSymbol("cube.transparent"),
         explanationText: [:],
-        shortExplanationText: [.enUS: "Improve your cardiovascular health"],
+        shortExplanationText: [
+            .enUS: "Improve your cardiovascular health",
+            .esES: "Mejora tu salud cardiovascular"
+        ],
         studyDependency: nil,
         participationCriterion: .ageAtLeast(18) && (.isFromRegion(.unitedStates) || .isFromRegion(.unitedKingdom)),
         consentFileRef: .init(category: .consent, filename: "Consent", fileExtension: "md")
@@ -327,3 +330,8 @@ let mhcStudyDefinition = StudyDefinition(
         )
     }
 )
+
+
+extension LocalizationKey {
+    static let esES = Self(language: .init(identifier: "es"), region: .spain)
+}


### PR DESCRIPTION
# [breaking change] update deps

## :recycle: Current situation & Problem
updates Spezi to the new repo; as part of this we also update from what used to be SpeziStudy 0.1.x to what used to be SpeziStudy 0.2.x


## :gear: Release Notes
- updated dependencies to point to new Spezi repo


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/extended localization for study metadata, including updated localized titles, explanations, and short text, with the study revision bumped to **41**.
* **Chores**
  * Updated supported platforms; **visionOS** support was removed.
  * Streamlined package dependencies by switching to the **Spezi** package and updating which products targets reference.
  * Adjusted concurrency isolation settings for the exporter library and CLI targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->