### PR TITLE
disable uk prod deployment

### DIFF
--- a/.github/workflows/publish-study-definition.yml
+++ b/.github/workflows/publish-study-definition.yml
@@ -195,6 +195,7 @@ jobs:
           gsutil ls gs://${{ needs.vars.outputs.FIREBASE_PROJECT_ID_PRODUCTION_US }}.firebasestorage.app/public/
 
       - name: (UK production) Decode and authenticate to Google Cloud
+        if: ${{ false }}
         run: |
           if [ -z "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64_PRODUCTION_UK }}" ]; then
             echo "ERROR: GOOGLE_APPLICATION_CREDENTIALS_BASE64_PRODUCTION_UK secret is not set"
@@ -216,12 +217,14 @@ jobs:
           gcloud config set project ${{ needs.vars.outputs.FIREBASE_PROJECT_ID_PRODUCTION_UK }}
 
       - name: (UK production) Upload study bundle to Firebase Storage
+        if: ${{ false }}
         run: |
           gsutil cp mhcStudyBundle.spezistudybundle.aar gs://${{ needs.vars.outputs.FIREBASE_PROJECT_ID_PRODUCTION_UK }}.firebasestorage.app/public/
 
           gsutil acl ch -u AllUsers:R gs://${{ needs.vars.outputs.FIREBASE_PROJECT_ID_PRODUCTION_UK }}.firebasestorage.app/public/mhcStudyBundle.spezistudybundle.aar
 
       - name: (UK production) Verify upload
+        if: ${{ false }}
         run: |
           # List the files in the public directory to confirm
           gsutil ls gs://${{ needs.vars.outputs.FIREBASE_PROJECT_ID_PRODUCTION_UK }}.firebasestorage.app/public/


### PR DESCRIPTION
# disable uk prod deployment

## :recycle: Current situation & Problem
all deployments currently fail, bc the uk step always fails. we should disable this for the time being, so that the status reported by GitHub is correct (the US deployment still succeeded, even if the workflow as a whole failed bc of the failing UK one)


## :gear: Release Notes
- disabled uk prod deployment


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/SchmiedmayerLab/codesmith/MyHeartCounts-StudyDefinitions/pr/37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785521694&installation_id=142325556&pr_number=37&repository=SchmiedmayerLab%2FMyHeartCounts-StudyDefinitions&return_to=https%3A%2F%2Fgithub.com%2FSchmiedmayerLab%2FMyHeartCounts-StudyDefinitions%2Fpull%2F37&signature=278358dac174e32ef1cc10234e59512abc258e5aad5b5d3543e8db5dcaea4bba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->